### PR TITLE
Fix error caused when passing empty array into setSpecialCaseTags

### DIFF
--- a/lib/Caxy/HtmlDiff/HtmlDiff.php
+++ b/lib/Caxy/HtmlDiff/HtmlDiff.php
@@ -67,9 +67,7 @@ class HtmlDiff
 
     public function setSpecialCaseTags(array $tags = array())
     {
-        if (!empty($tags)) {
-            $this->specialCaseTags = $tags;
-        }
+        $this->specialCaseTags = $tags;
 
         foreach ($this->specialCaseTags as $tag) {
             $this->addSpecialCaseTag($tag);


### PR DESCRIPTION
Fixes: `Warning: Invalid argument supplied for foreach() in vendor/caxy/php-htmldiff/lib/Caxy/HtmlDiff/HtmlDiff.php line 74` when passing in an empty array for specialCaseTags
