### PR TITLE
Detect link changes to resolve #28

### DIFF
--- a/tests/fixtures/HtmlDiff/issue-28-link-changes.html
+++ b/tests/fixtures/HtmlDiff/issue-28-link-changes.html
@@ -1,0 +1,15 @@
+<oldText>
+Testing <a href="http://google.com">Link Changes</a>
+And when the link <a href="http://samelink.com">stays the same</a>
+</oldText>
+
+<newText>
+Testing <a href="http://caxy.com">Link Changes</a>
+And when the link <a href="http://samelink.com">stays the same</a>
+</newText>
+
+<expected>
+Testing <del class="diffmod diff-href"><a href="http://google.com">Link Changes</a></del><ins class="diffmod diff-href"><a href="http://caxy.com">Link Changes</a></ins>
+ And when the link <a href="http://samelink.com">stays the same</a>
+</expected>
+


### PR DESCRIPTION
Feature request from #28.

I didn't go as far as adding the functionality for displaying a tooltip of the change, as that is out of the scope of this library and could be done with some post-processing / JS.

Example:

Old Text: `<a href="http://caxy.com">Test</a>`

New Text: `<a href="http://google.com">Test</a>`

Output:
```html
<del class="diffmod diff-href"><a href="http://caxy.com">Test</a></del><ins class="diffmod diff-href"><a href="http://google.com">Test</a></ins>
```