### PR TITLE
Create configuration class for HtmlDiff config options

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -30,5 +30,10 @@
     },
     "require-dev": {
         "phpunit/phpunit": "^4.8"
+    },
+    "extra": {
+        "branch-alias": {
+            "dev-master": "0.1.x-dev"
+        }
     }
 }

--- a/lib/Caxy/HtmlDiff/AbstractDiff.php
+++ b/lib/Caxy/HtmlDiff/AbstractDiff.php
@@ -10,16 +10,27 @@ abstract class AbstractDiff
 {
     /**
      * @var array
+     *
+     * @deprecated since 0.1.0
      */
     public static $defaultSpecialCaseTags = array('strong', 'b', 'i', 'big', 'small', 'u', 'sub', 'sup', 'strike', 's', 'p');
     /**
      * @var array
+     *
+     * @deprecated since 0.1.0
      */
     public static $defaultSpecialCaseChars = array('.', ',', '(', ')', '\'');
     /**
      * @var bool
+     *
+     * @deprecated since 0.1.0
      */
     public static $defaultGroupDiffs = true;
+
+    /**
+     * @var HtmlDiffConfig
+     */
+    protected $config;
 
     /**
      * @var string
@@ -41,34 +52,6 @@ abstract class AbstractDiff
      * @var array
      */
     protected $newWords = array();
-    /**
-     * @var string
-     */
-    protected $encoding;
-    /**
-     * @var array
-     */
-    protected $specialCaseOpeningTags = array();
-    /**
-     * @var array
-     */
-    protected $specialCaseClosingTags = array();
-    /**
-     * @var array|null
-     */
-    protected $specialCaseTags;
-    /**
-     * @var array|null
-     */
-    protected $specialCaseChars;
-    /**
-     * @var bool|null
-     */
-    protected $groupDiffs;
-    /**
-     * @var int
-     */
-    protected $matchThreshold = 80;
 
     /**
      * AbstractDiff constructor.
@@ -83,138 +66,143 @@ abstract class AbstractDiff
     {
         mb_substitute_character(0x20);
 
-        if ($specialCaseTags === null) {
-            $specialCaseTags = static::$defaultSpecialCaseTags;
+        $this->config = HtmlDiffConfig::create()->setEncoding($encoding);
+
+        if ($specialCaseTags !== null) {
+            $this->config->setSpecialCaseTags($specialCaseTags);
         }
 
-        if ($groupDiffs === null) {
-            $groupDiffs = static::$defaultGroupDiffs;
+        if ($groupDiffs !== null) {
+            $this->config->setGroupDiffs($groupDiffs);
         }
 
         $this->oldText = $this->purifyHtml(trim($oldText));
         $this->newText = $this->purifyHtml(trim($newText));
-        $this->encoding = $encoding;
         $this->content = '';
-        $this->groupDiffs = $groupDiffs;
-        $this->setSpecialCaseTags($specialCaseTags);
-        $this->setSpecialCaseChars(static::$defaultSpecialCaseChars);
+    }
+
+    /**
+     * @return HtmlDiffConfig
+     */
+    public function getConfig()
+    {
+        return $this->config;
+    }
+
+    /**
+     * @param HtmlDiffConfig $config
+     *
+     * @return AbstractDiff
+     */
+    public function setConfig(HtmlDiffConfig $config)
+    {
+        $this->config = $config;
+
+        return $this;
     }
 
     /**
      * @return int
+     *
+     * @deprecated since 0.1.0
      */
     public function getMatchThreshold()
     {
-        return $this->matchThreshold;
+        return $this->config->getMatchThreshold();
     }
 
     /**
      * @param int $matchThreshold
      *
      * @return AbstractDiff
+     *
+     * @deprecated since 0.1.0
      */
     public function setMatchThreshold($matchThreshold)
     {
-        $this->matchThreshold = $matchThreshold;
+        $this->config->setMatchThreshold($matchThreshold);
 
         return $this;
     }
 
     /**
      * @param array $chars
+     *
+     * @deprecated since 0.1.0
      */
     public function setSpecialCaseChars(array $chars)
     {
-        $this->specialCaseChars = $chars;
+        $this->config->setSpecialCaseChars($chars);
     }
 
     /**
      * @return array|null
+     *
+     * @deprecated since 0.1.0
      */
     public function getSpecialCaseChars()
     {
-        return $this->specialCaseChars;
+        return $this->config->getSpecialCaseChars();
     }
 
     /**
      * @param string $char
+     *
+     * @deprecated since 0.1.0
      */
     public function addSpecialCaseChar($char)
     {
-        if (!in_array($char, $this->specialCaseChars)) {
-            $this->specialCaseChars[] = $char;
-        }
+        $this->config->addSpecialCaseChar($char);
     }
 
     /**
      * @param string $char
+     *
+     * @deprecated since 0.1.0
      */
     public function removeSpecialCaseChar($char)
     {
-        $key = array_search($char, $this->specialCaseChars);
-        if ($key !== false) {
-            unset($this->specialCaseChars[$key]);
-        }
+        $this->config->removeSpecialCaseChar($char);
     }
 
     /**
      * @param array $tags
+     *
+     * @deprecated since 0.1.0
      */
     public function setSpecialCaseTags(array $tags = array())
     {
-        $this->specialCaseTags = $tags;
-
-        foreach ($this->specialCaseTags as $tag) {
-            $this->addSpecialCaseTag($tag);
-        }
+        $this->config->setSpecialCaseChars($tags);
     }
 
     /**
      * @param string $tag
+     *
+     * @deprecated since 0.1.0
      */
     public function addSpecialCaseTag($tag)
     {
-        if (!in_array($tag, $this->specialCaseTags)) {
-            $this->specialCaseTags[] = $tag;
-        }
-
-        $opening = $this->getOpeningTag($tag);
-        $closing = $this->getClosingTag($tag);
-
-        if (!in_array($opening, $this->specialCaseOpeningTags)) {
-            $this->specialCaseOpeningTags[] = $opening;
-        }
-        if (!in_array($closing, $this->specialCaseClosingTags)) {
-            $this->specialCaseClosingTags[] = $closing;
-        }
+        $this->config->addSpecialCaseTag($tag);
     }
 
     /**
      * @param string $tag
+     *
+     * @deprecated since 0.1.0
      */
     public function removeSpecialCaseTag($tag)
     {
-        if (($key = array_search($tag, $this->specialCaseTags)) !== false) {
-            unset($this->specialCaseTags[$key]);
-
-            $opening = $this->getOpeningTag($tag);
-            $closing = $this->getClosingTag($tag);
-
-            if (($key = array_search($opening, $this->specialCaseOpeningTags)) !== false) {
-                unset($this->specialCaseOpeningTags[$key]);
-            }
-            if (($key = array_search($closing, $this->specialCaseClosingTags)) !== false) {
-                unset($this->specialCaseClosingTags[$key]);
-            }
-        }
+        $this->config->removeSpecialCaseTag($tag);
     }
 
     /**
      * @return array|null
+     *
+     * @deprecated since 0.1.0
      */
     public function getSpecialCaseTags()
     {
-        return $this->specialCaseTags;
+        return $this->config->getSpecialCaseTags();
     }
 
     /**
@@ -245,20 +233,24 @@ abstract class AbstractDiff
      * @param bool $boolean
      *
      * @return $this
+     *
+     * @deprecated since 0.1.0
      */
     public function setGroupDiffs($boolean)
     {
-        $this->groupDiffs = $boolean;
+        $this->config->setGroupDiffs($boolean);
 
         return $this;
     }
 
     /**
      * @return bool
+     *
+     * @deprecated since 0.1.0
      */
     public function isGroupDiffs()
     {
-        return $this->groupDiffs;
+        return $this->config->isGroupDiffs();
     }
 
     /**
@@ -335,7 +327,7 @@ abstract class AbstractDiff
      */
     protected function isPartOfWord($text)
     {
-        return ctype_alnum(str_replace($this->specialCaseChars, '', $text));
+        return ctype_alnum(str_replace($this->config->getSpecialCaseChars(), '', $text));
     }
 
     /**
@@ -366,7 +358,7 @@ abstract class AbstractDiff
                 } else {
                     if (
                         (ctype_alnum($character) && (strlen($current_word) == 0 || $this->isPartOfWord($current_word))) ||
-                        (in_array($character, $this->specialCaseChars) && isset($characterString[$i+1]) && $this->isPartOfWord($characterString[$i+1]))
+                        (in_array($character, $this->config->getSpecialCaseChars()) && isset($characterString[$i+1]) && $this->isPartOfWord($characterString[$i+1]))
                     ) {
                         $current_word .= $character;
                     } else {

--- a/lib/Caxy/HtmlDiff/HtmlDiffConfig.php
+++ b/lib/Caxy/HtmlDiff/HtmlDiffConfig.php
@@ -1,0 +1,438 @@
+<?php
+
+namespace Caxy\HtmlDiff;
+
+/**
+ * Class HtmlDiffConfig
+ * @package Caxy\HtmlDiff
+ */
+class HtmlDiffConfig
+{
+    /**
+     * @var array
+     */
+    protected $specialCaseTags = array('strong', 'b', 'i', 'big', 'small', 'u', 'sub', 'sup', 'strike', 's', 'p');
+
+    /**
+     * @var array
+     */
+    protected $specialCaseChars = array('.', ',', '(', ')', '\'');
+
+    /**
+     * @var bool
+     */
+    protected $groupDiffs = true;
+
+    /**
+     * @var bool
+     */
+    protected $insertSpaceInReplace = false;
+
+    /**
+     * @var string
+     */
+    protected $encoding = 'UTF-8';
+
+    /**
+     * @var array
+     */
+    protected $isolatedDiffTags = array(
+        'ol'     => '[[REPLACE_ORDERED_LIST]]',
+        'ul'     => '[[REPLACE_UNORDERED_LIST]]',
+        'sub'    => '[[REPLACE_SUB_SCRIPT]]',
+        'sup'    => '[[REPLACE_SUPER_SCRIPT]]',
+        'dl'     => '[[REPLACE_DEFINITION_LIST]]',
+        'table'  => '[[REPLACE_TABLE]]',
+        'strong' => '[[REPLACE_STRONG]]',
+        'b'      => '[[REPLACE_B]]',
+        'em'     => '[[REPLACE_EM]]',
+        'i'      => '[[REPLACE_I]]',
+        'a'      => '[[REPLACE_A]]',
+    );
+
+    /**
+     * @var int
+     */
+    protected $matchThreshold = 80;
+    /**
+     * @var array
+     */
+    protected $specialCaseOpeningTags = array();
+    /**
+     * @var array
+     */
+    protected $specialCaseClosingTags = array();
+
+    /**
+     * @var bool
+     */
+    protected $useTableDiffing = true;
+
+    /**
+     * @return HtmlDiffConfig
+     */
+    public static function create()
+    {
+        return new self();
+    }
+
+    /**
+     * HtmlDiffConfig constructor.
+     */
+    public function __construct()
+    {
+        $this->setSpecialCaseTags($this->specialCaseTags);
+    }
+
+    /**
+     * @return int
+     */
+    public function getMatchThreshold()
+    {
+        return $this->matchThreshold;
+    }
+
+    /**
+     * @param int $matchThreshold
+     *
+     * @return AbstractDiff
+     */
+    public function setMatchThreshold($matchThreshold)
+    {
+        $this->matchThreshold = $matchThreshold;
+
+        return $this;
+    }
+
+    /**
+     * @param array $chars
+     */
+    public function setSpecialCaseChars(array $chars)
+    {
+        $this->specialCaseChars = $chars;
+    }
+
+    /**
+     * @return array|null
+     */
+    public function getSpecialCaseChars()
+    {
+        return $this->specialCaseChars;
+    }
+
+    /**
+     * @param string $char
+     *
+     * @return $this
+     */
+    public function addSpecialCaseChar($char)
+    {
+        if (!in_array($char, $this->specialCaseChars)) {
+            $this->specialCaseChars[] = $char;
+        }
+
+        return $this;
+    }
+
+    /**
+     * @param string $char
+     *
+     * @return $this
+     */
+    public function removeSpecialCaseChar($char)
+    {
+        $key = array_search($char, $this->specialCaseChars);
+        if ($key !== false) {
+            unset($this->specialCaseChars[$key]);
+        }
+
+        return $this;
+    }
+
+    /**
+     * @param array $tags
+     *
+     * @return $this
+     */
+    public function setSpecialCaseTags(array $tags = array())
+    {
+        $this->specialCaseTags = $tags;
+        $this->specialCaseOpeningTags = array();
+        $this->specialCaseClosingTags = array();
+
+        foreach ($this->specialCaseTags as $tag) {
+            $this->addSpecialCaseTag($tag);
+        }
+
+        return $this;
+    }
+
+    /**
+     * @param string $tag
+     *
+     * @return $this
+     */
+    public function addSpecialCaseTag($tag)
+    {
+        if (!in_array($tag, $this->specialCaseTags)) {
+            $this->specialCaseTags[] = $tag;
+        }
+
+        $opening = $this->getOpeningTag($tag);
+        $closing = $this->getClosingTag($tag);
+
+        if (!in_array($opening, $this->specialCaseOpeningTags)) {
+            $this->specialCaseOpeningTags[] = $opening;
+        }
+        if (!in_array($closing, $this->specialCaseClosingTags)) {
+            $this->specialCaseClosingTags[] = $closing;
+        }
+
+        return $this;
+    }
+
+    /**
+     * @param string $tag
+     *
+     * @return $this
+     */
+    public function removeSpecialCaseTag($tag)
+    {
+        if (($key = array_search($tag, $this->specialCaseTags)) !== false) {
+            unset($this->specialCaseTags[$key]);
+
+            $opening = $this->getOpeningTag($tag);
+            $closing = $this->getClosingTag($tag);
+
+            if (($key = array_search($opening, $this->specialCaseOpeningTags)) !== false) {
+                unset($this->specialCaseOpeningTags[$key]);
+            }
+            if (($key = array_search($closing, $this->specialCaseClosingTags)) !== false) {
+                unset($this->specialCaseClosingTags[$key]);
+            }
+        }
+
+        return $this;
+    }
+
+    /**
+     * @return array|null
+     */
+    public function getSpecialCaseTags()
+    {
+        return $this->specialCaseTags;
+    }
+
+
+    /**
+     * @return boolean
+     */
+    public function isGroupDiffs()
+    {
+        return $this->groupDiffs;
+    }
+
+    /**
+     * @param boolean $groupDiffs
+     *
+     * @return HtmlDiffConfig
+     */
+    public function setGroupDiffs($groupDiffs)
+    {
+        $this->groupDiffs = $groupDiffs;
+
+        return $this;
+    }
+
+    /**
+     * @return string
+     */
+    public function getEncoding()
+    {
+        return $this->encoding;
+    }
+
+    /**
+     * @param string $encoding
+     *
+     * @return HtmlDiffConfig
+     */
+    public function setEncoding($encoding)
+    {
+        $this->encoding = $encoding;
+
+        return $this;
+    }
+
+    /**
+     * @return boolean
+     */
+    public function isInsertSpaceInReplace()
+    {
+        return $this->insertSpaceInReplace;
+    }
+
+    /**
+     * @param boolean $insertSpaceInReplace
+     *
+     * @return HtmlDiffConfig
+     */
+    public function setInsertSpaceInReplace($insertSpaceInReplace)
+    {
+        $this->insertSpaceInReplace = $insertSpaceInReplace;
+
+        return $this;
+    }
+
+    /**
+     * @return array
+     */
+    public function getIsolatedDiffTags()
+    {
+        return $this->isolatedDiffTags;
+    }
+
+    /**
+     * @param array $isolatedDiffTags
+     *
+     * @return HtmlDiffConfig
+     */
+    public function setIsolatedDiffTags($isolatedDiffTags)
+    {
+        $this->isolatedDiffTags = $isolatedDiffTags;
+
+        return $this;
+    }
+
+    /**
+     * @param string      $tag
+     * @param null|string $placeholder
+     *
+     * @return $this
+     */
+    public function addIsolatedDiffTag($tag, $placeholder = null)
+    {
+        if (null === $placeholder) {
+            $placeholder = sprintf('[[REPLACE_%s]]', strtoupper($tag));
+        }
+
+        if ($this->isIsolatedDiffTag($tag) && $this->isolatedDiffTags[$tag] !== $placeholder) {
+            throw new \InvalidArgumentException(
+                sprintf('Isolated diff tag "%s" already exists using a different placeholder', $tag)
+            );
+        }
+
+        $matchingKey = array_search($placeholder, $this->isolatedDiffTags, true);
+        if (false !== $matchingKey && $matchingKey !== $tag) {
+            throw new \InvalidArgumentException(
+                sprintf('Placeholder already being used for a different tag "%s"', $tag)
+            );
+        }
+
+        if (!array_key_exists($tag, $this->isolatedDiffTags)) {
+            $this->isolatedDiffTags[$tag] = $placeholder;
+        }
+
+        return $this;
+    }
+
+    /**
+     * @param string $tag
+     *
+     * @return $this
+     */
+    public function removeIsolatedDiffTag($tag)
+    {
+        if ($this->isIsolatedDiffTag($tag)) {
+            unset($this->isolatedDiffTags[$tag]);
+        }
+
+        return $this;
+    }
+
+    /**
+     * @param string $tag
+     *
+     * @return bool
+     */
+    public function isIsolatedDiffTag($tag)
+    {
+        return array_key_exists($tag, $this->isolatedDiffTags);
+    }
+
+    /**
+     * @param string $text
+     *
+     * @return bool
+     */
+    public function isIsolatedDiffTagPlaceholder($text)
+    {
+        return in_array($text, $this->isolatedDiffTags, true);
+    }
+
+    /**
+     * @param string $tag
+     *
+     * @return null|string
+     */
+    public function getIsolatedDiffTagPlaceholder($tag)
+    {
+        return $this->isIsolatedDiffTag($tag) ? $this->isolatedDiffTags[$tag] : null;
+    }
+
+    /**
+     * @return array
+     */
+    public function getSpecialCaseOpeningTags()
+    {
+        return $this->specialCaseOpeningTags;
+    }
+
+    /**
+     * @return array
+     */
+    public function getSpecialCaseClosingTags()
+    {
+        return $this->specialCaseClosingTags;
+    }
+
+    /**
+     * @return boolean
+     */
+    public function isUseTableDiffing()
+    {
+        return $this->useTableDiffing;
+    }
+
+    /**
+     * @param boolean $useTableDiffing
+     *
+     * @return HtmlDiffConfig
+     */
+    public function setUseTableDiffing($useTableDiffing)
+    {
+        $this->useTableDiffing = $useTableDiffing;
+
+        return $this;
+    }
+
+    /**
+     * @param string $tag
+     *
+     * @return string
+     */
+    protected function getOpeningTag($tag)
+    {
+        return "/<".$tag."[^>]*/i";
+    }
+
+    /**
+     * @param string $tag
+     *
+     * @return string
+     */
+    protected function getClosingTag($tag)
+    {
+        return "</".$tag.">";
+    }
+}


### PR DESCRIPTION
Created a new class `Caxy\HtmlDiff\HtmlDiffConfig` to house the configuration options for HtmlDiff/ListDiff/TableDiff in an object. We've added a decent amount of config options to the HtmlDiff class, and it's getting quite messy having to pass these options individually into each new instance of ListDiff/TableDiff/HtmlDiff that we end up creating. So now we can just pass the object along!

In order to be backwards-compatible, I left the __construct intact as well as the public getter/setter functions for the config options, but I marked them as deprecated.

Use `HtmlDiff::setConfig` to set the configuration object. The __construct is currently creating a new instance of HtmlDiffConfig with the default options by default, so you don't actually need to create a new object if you don't want to. You can simply call `HtmlDiff::getConfig` to get the object and then use the (fluent) setter functions to set configuration options.