### PR TITLE
Allow caching of the calculated diffs using a doctrine cache provider

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,6 +26,9 @@
         "phpunit/phpunit": "^4.8",
         "doctrine/cache": "^1.6"
     },
+    "suggest": {
+        "doctrine/cache": "Used for caching the calculated diffs using a Doctrine Cache Provider"
+    },
     "autoload": {
         "psr-0": { "Caxy\\HtmlDiff": "lib/" }
     },

--- a/composer.json
+++ b/composer.json
@@ -23,8 +23,8 @@
         "ezyang/htmlpurifier": "^4.7"
     },
     "require-dev": {
-        "phpunit/phpunit": "^4.8",
-        "doctrine/cache": "^1.6"
+        "phpunit/phpunit": "~4.8",
+        "doctrine/cache": "~1.0"
     },
     "suggest": {
         "doctrine/cache": "Used for caching the calculated diffs using a Doctrine Cache Provider"

--- a/composer.json
+++ b/composer.json
@@ -22,14 +22,15 @@
         "php": ">=5.3.3",
         "ezyang/htmlpurifier": "^4.7"
     },
+    "require-dev": {
+        "phpunit/phpunit": "^4.8",
+        "doctrine/cache": "^1.6"
+    },
     "autoload": {
         "psr-0": { "Caxy\\HtmlDiff": "lib/" }
     },
     "autoload-dev": {
         "psr-4": { "Caxy\\Tests\\": "tests/Caxy/Tests" }
-    },
-    "require-dev": {
-        "phpunit/phpunit": "^4.8"
     },
     "extra": {
         "branch-alias": {

--- a/lib/Caxy/HtmlDiff/AbstractDiff.php
+++ b/lib/Caxy/HtmlDiff/AbstractDiff.php
@@ -82,6 +82,43 @@ abstract class AbstractDiff
     }
 
     /**
+     * @return bool|string
+     */
+    abstract public function build();
+
+    public function getCachedDiff($oldText, $newText)
+    {
+        if (!$this->hasCachedDiff($oldText, $newText)) {
+            return false;
+        }
+
+        return $this->getConfig()->getCacheProvider()->fetch($this->getHashKey($oldText, $newText));
+    }
+
+    public function setCachedDiff($oldText, $newText, $text)
+    {
+        if (null === $this->getConfig()->getCacheProvider()) {
+            return false;
+        }
+
+        return $this->getConfig()->getCacheProvider()->save($this->getHashKey($oldText, $newText), $text);
+    }
+
+    public function hasCachedDiff($oldText, $newText)
+    {
+        if (null === $this->getConfig()->getCacheProvider()) {
+            return false;
+        }
+
+        return $this->getConfig()->getCacheProvider()->contains($this->getHashKey($oldText, $newText));
+    }
+
+    protected function getHashKey($oldText, $newText)
+    {
+        return sprintf('%s_%s', md5($oldText), md5($newText));
+    }
+
+    /**
      * @return HtmlDiffConfig
      */
     public function getConfig()

--- a/lib/Caxy/HtmlDiff/DiffCache.php
+++ b/lib/Caxy/HtmlDiff/DiffCache.php
@@ -1,0 +1,112 @@
+<?php
+
+namespace Caxy\HtmlDiff;
+
+use Doctrine\Common\Cache\Cache;
+
+/**
+ * Class DiffCache
+ * @package Caxy\HtmlDiff
+ */
+class DiffCache
+{
+    /**
+     * @var Cache
+     */
+    protected $cacheProvider;
+
+    /**
+     * DiffCache constructor.
+     *
+     * @param Cache $cacheProvider
+     */
+    public function __construct(Cache $cacheProvider)
+    {
+        $this->cacheProvider = $cacheProvider;
+    }
+
+    /**
+     * @return Cache
+     */
+    public function getCacheProvider()
+    {
+        return $this->cacheProvider;
+    }
+
+    /**
+     * @param Cache $cacheProvider
+     *
+     * @return DiffCache
+     */
+    public function setCacheProvider($cacheProvider)
+    {
+        $this->cacheProvider = $cacheProvider;
+
+        return $this;
+    }
+
+    /**
+     * @param string $oldText
+     * @param string $newText
+     *
+     * @return bool
+     */
+    public function contains($oldText, $newText)
+    {
+        return $this->cacheProvider->contains($this->getHashKey($oldText, $newText));
+    }
+
+    /**
+     * @param string $oldText
+     * @param string $newText
+     *
+     * @return string
+     */
+    public function fetch($oldText, $newText)
+    {
+        return $this->cacheProvider->fetch($this->getHashKey($oldText, $newText));
+    }
+
+    /**
+     * @param string $oldText
+     * @param string $newText
+     * @param string $data
+     * @param int    $lifeTime
+     *
+     * @return bool
+     */
+    public function save($oldText, $newText, $data, $lifeTime = 0)
+    {
+        return $this->cacheProvider->save($this->getHashKey($oldText, $newText), $data, $lifeTime);
+    }
+
+    /**
+     * @param string $oldText
+     * @param string $newText
+     *
+     * @return bool
+     */
+    public function delete($oldText, $newText)
+    {
+        return $this->cacheProvider->delete($this->getHashKey($oldText, $newText));
+    }
+
+    /**
+     * @return array|null
+     */
+    public function getStats()
+    {
+        return $this->cacheProvider->getStats();
+    }
+
+    /**
+     * @param string $oldText
+     * @param string $newText
+     *
+     * @return string
+     */
+    protected function getHashKey($oldText, $newText)
+    {
+        return sprintf('%s_%s', md5($oldText), md5($newText));
+    }
+}

--- a/lib/Caxy/HtmlDiff/HtmlDiff.php
+++ b/lib/Caxy/HtmlDiff/HtmlDiff.php
@@ -91,8 +91,8 @@ class HtmlDiff extends AbstractDiff
      */
     public function build()
     {
-        if ($this->hasCachedDiff($this->oldText, $this->newText)) {
-            $this->content = $this->getCachedDiff($this->oldText, $this->newText);
+        if ($this->hasDiffCache() && $this->getDiffCache()->contains($this->oldText, $this->newText)) {
+            $this->content = $this->getDiffCache()->fetch($this->oldText, $this->newText);
 
             return $this->content;
         }
@@ -106,7 +106,9 @@ class HtmlDiff extends AbstractDiff
             $this->performOperation( $item );
         }
 
-        $this->setCachedDiff($this->oldText, $this->newText, $this->content);
+        if ($this->hasDiffCache()) {
+            $this->getDiffCache()->save($this->oldText, $this->newText, $this->content);
+        }
 
         return $this->content;
     }

--- a/lib/Caxy/HtmlDiff/HtmlDiff.php
+++ b/lib/Caxy/HtmlDiff/HtmlDiff.php
@@ -91,6 +91,12 @@ class HtmlDiff extends AbstractDiff
      */
     public function build()
     {
+        if ($this->hasCachedDiff($this->oldText, $this->newText)) {
+            $this->content = $this->getCachedDiff($this->oldText, $this->newText);
+
+            return $this->content;
+        }
+
         $this->splitInputsToWords();
         $this->replaceIsolatedDiffTags();
         $this->indexNewWords();
@@ -99,6 +105,8 @@ class HtmlDiff extends AbstractDiff
         foreach ($operations as $item) {
             $this->performOperation( $item );
         }
+
+        $this->setCachedDiff($this->oldText, $this->newText, $this->content);
 
         return $this->content;
     }

--- a/lib/Caxy/HtmlDiff/HtmlDiffConfig.php
+++ b/lib/Caxy/HtmlDiff/HtmlDiffConfig.php
@@ -69,6 +69,11 @@ class HtmlDiffConfig
     protected $useTableDiffing = true;
 
     /**
+     * @var null|\Doctrine\Common\Cache\Cache
+     */
+    protected $cacheProvider;
+
+    /**
      * @return HtmlDiffConfig
      */
     public static function create()
@@ -414,6 +419,26 @@ class HtmlDiffConfig
         $this->useTableDiffing = $useTableDiffing;
 
         return $this;
+    }
+
+    /**
+     * @param null|\Doctrine\Common\Cache\Cache $cacheProvider
+     *
+     * @return $this
+     */
+    public function setCacheProvider(\Doctrine\Common\Cache\Cache $cacheProvider = null)
+    {
+        $this->cacheProvider = $cacheProvider;
+
+        return $this;
+    }
+
+    /**
+     * @return null|\Doctrine\Common\Cache\Cache
+     */
+    public function getCacheProvider()
+    {
+        return $this->cacheProvider;
     }
 
     /**

--- a/lib/Caxy/HtmlDiff/ListDiffNew.php
+++ b/lib/Caxy/HtmlDiff/ListDiffNew.php
@@ -29,8 +29,8 @@ class ListDiffNew extends AbstractDiff
 
     public function build()
     {
-        if ($this->hasCachedDiff($this->oldText, $this->newText)) {
-            $this->content = $this->getCachedDiff($this->oldText, $this->newText);
+        if ($this->hasDiffCache() && $this->getDiffCache()->contains($this->oldText, $this->newText)) {
+            $this->content = $this->getDiffCache()->fetch($this->oldText, $this->newText);
 
             return $this->content;
         }
@@ -42,7 +42,9 @@ class ListDiffNew extends AbstractDiff
             $this->buildDiffList($this->newWords)
         );
 
-        $this->setCachedDiff($this->oldText, $this->newText, $this->content);
+        if ($this->hasDiffCache()) {
+            $this->getDiffCache()->save($this->oldText, $this->newText, $this->content);
+        }
 
         return $this->content;
     }

--- a/lib/Caxy/HtmlDiff/ListDiffNew.php
+++ b/lib/Caxy/HtmlDiff/ListDiffNew.php
@@ -29,12 +29,22 @@ class ListDiffNew extends AbstractDiff
 
     public function build()
     {
+        if ($this->hasCachedDiff($this->oldText, $this->newText)) {
+            $this->content = $this->getCachedDiff($this->oldText, $this->newText);
+
+            return $this->content;
+        }
+
         $this->splitInputsToWords();
 
-        return $this->diffLists(
+        $this->content = $this->diffLists(
             $this->buildDiffList($this->oldWords),
             $this->buildDiffList($this->newWords)
         );
+
+        $this->setCachedDiff($this->oldText, $this->newText, $this->content);
+
+        return $this->content;
     }
 
     protected function diffLists(DiffList $oldList, DiffList $newList)

--- a/lib/Caxy/HtmlDiff/Table/TableDiff.php
+++ b/lib/Caxy/HtmlDiff/Table/TableDiff.php
@@ -92,8 +92,8 @@ class TableDiff extends AbstractDiff
      */
     public function build()
     {
-        if ($this->hasCachedDiff($this->oldText, $this->newText)) {
-            $this->content = $this->getCachedDiff($this->oldText, $this->newText);
+        if ($this->hasDiffCache() && $this->getDiffCache()->contains($this->oldText, $this->newText)) {
+            $this->content = $this->getDiffCache()->fetch($this->oldText, $this->newText);
 
             return $this->content;
         }
@@ -106,7 +106,9 @@ class TableDiff extends AbstractDiff
 
         $this->diffTableContent();
 
-        $this->setCachedDiff($this->oldText, $this->newText, $this->content);
+        if ($this->hasDiffCache()) {
+            $this->getDiffCache()->save($this->oldText, $this->newText, $this->content);
+        }
 
         return $this->content;
     }

--- a/lib/Caxy/HtmlDiff/Table/TableDiff.php
+++ b/lib/Caxy/HtmlDiff/Table/TableDiff.php
@@ -92,6 +92,12 @@ class TableDiff extends AbstractDiff
      */
     public function build()
     {
+        if ($this->hasCachedDiff($this->oldText, $this->newText)) {
+            $this->content = $this->getCachedDiff($this->oldText, $this->newText);
+
+            return $this->content;
+        }
+
         $this->buildTableDoms();
 
         $this->diffDom = new \DOMDocument();
@@ -99,6 +105,8 @@ class TableDiff extends AbstractDiff
         $this->indexCellValues($this->newTable);
 
         $this->diffTableContent();
+
+        $this->setCachedDiff($this->oldText, $this->newText, $this->content);
 
         return $this->content;
     }


### PR DESCRIPTION
Allows setting an object that implements the `Doctrine\Common\Cache\Cache` interface on the `Caxy\HtmlDiff\HtmlDiffConfig` object. If this is set, then that cache provider will be used to cache the calculated diff contents.

Needs test coverage.