### PR TITLE
Update TableDiff HTMLPurifier Initialization.

### DIFF
--- a/lib/Caxy/HtmlDiff/HtmlDiffConfig.php
+++ b/lib/Caxy/HtmlDiff/HtmlDiffConfig.php
@@ -74,7 +74,7 @@ class HtmlDiffConfig
     protected $cacheProvider;
 
     /**
-     * @var null|String
+     * @var null|string
      */
     protected $purifierCacheLocation = null;
 

--- a/lib/Caxy/HtmlDiff/HtmlDiffConfig.php
+++ b/lib/Caxy/HtmlDiff/HtmlDiffConfig.php
@@ -74,6 +74,11 @@ class HtmlDiffConfig
     protected $cacheProvider;
 
     /**
+     * @var null|String
+     */
+    protected $purifierCacheLocation = null;
+
+    /**
      * @return HtmlDiffConfig
      */
     public static function create()
@@ -439,6 +444,26 @@ class HtmlDiffConfig
     public function getCacheProvider()
     {
         return $this->cacheProvider;
+    }
+
+    /**
+     * @param null|string
+     *
+     * @return $this
+     */
+    public function setPurifierCacheLocation($purifierCacheLocation = null)
+    {
+        $this->purifierCacheLocation = $purifierCacheLocation;
+
+        return $this;
+    }
+
+    /**
+     * @return null|string
+     */
+    public function getPurifierCacheLocation()
+    {
+        return $this->purifierCacheLocation;
     }
 
     /**

--- a/lib/Caxy/HtmlDiff/Table/TableDiff.php
+++ b/lib/Caxy/HtmlDiff/Table/TableDiff.php
@@ -106,7 +106,9 @@ class TableDiff extends AbstractDiff
         // Cache.SerializerPath defaults to Null and sets
         // the location to inside the vendor HTMLPurifier library
         // under the DefinitionCache/Serializer folder.
-        $HTMLPurifierConfig->set('Cache.SerializerPath', $defaultPurifierSerializerCache);
+        if (!is_null($defaultPurifierSerializerCache)) {
+            $HTMLPurifierConfig->set('Cache.SerializerPath', $defaultPurifierSerializerCache);
+        }
         $this->purifier = new \HTMLPurifier($HTMLPurifierConfig);
     }
 

--- a/lib/Caxy/HtmlDiff/Table/TableDiff.php
+++ b/lib/Caxy/HtmlDiff/Table/TableDiff.php
@@ -66,6 +66,8 @@ class TableDiff extends AbstractDiff
 
         if (null !== $config) {
             $diff->setConfig($config);
+
+            $this->initPurifier($config->getPurifierCacheLocation());
         }
 
         return $diff;
@@ -80,11 +82,32 @@ class TableDiff extends AbstractDiff
      * @param array|null $specialCaseTags
      * @param bool|null  $groupDiffs
      */
-    public function __construct($oldText, $newText, $encoding = 'UTF-8', $specialCaseTags = null, $groupDiffs = null)
+    public function __construct(
+        $oldText,
+        $newText,
+        $encoding = 'UTF-8',
+        $specialCaseTags = null,
+        $groupDiffs = null,
+        $defaultPurifierSerializerCache = null
+    )
     {
         parent::__construct($oldText, $newText, $encoding, $specialCaseTags, $groupDiffs);
 
-        $this->purifier = new \HTMLPurifier(\HTMLPurifier_Config::createDefault());
+        $this->initPurifier($defaultPurifierSerializerCache);
+    }
+
+    /**
+     * Initializes HTMLPurifier with cache location
+     * @param  null|string $defaultPurifierSerializerCache
+     * @return void
+     */
+    protected function initPurifier($defaultPurifierSerializerCache)
+    {
+        $HTMLPurifierConfig = \HTMLPurifier_Config::createDefault();
+        // Cache for the serializer defaults to inside the HTMLPurifier library
+        // under the DefinitionCache/Serializer folder.
+        $HTMLPurifierConfig->set('Cache.SerializerPath', $defaultPurifierSerializerCache);
+        $this->purifier = new \HTMLPurifier($HTMLPurifierConfig);
     }
 
     /**

--- a/lib/Caxy/HtmlDiff/Table/TableDiff.php
+++ b/lib/Caxy/HtmlDiff/Table/TableDiff.php
@@ -87,13 +87,12 @@ class TableDiff extends AbstractDiff
         $newText,
         $encoding = 'UTF-8',
         $specialCaseTags = null,
-        $groupDiffs = null,
-        $defaultPurifierSerializerCache = null
+        $groupDiffs = null
     )
     {
         parent::__construct($oldText, $newText, $encoding, $specialCaseTags, $groupDiffs);
 
-        $this->initPurifier($defaultPurifierSerializerCache);
+        $this->initPurifier();
     }
 
     /**
@@ -101,10 +100,11 @@ class TableDiff extends AbstractDiff
      * @param  null|string $defaultPurifierSerializerCache
      * @return void
      */
-    protected function initPurifier($defaultPurifierSerializerCache)
+    protected function initPurifier($defaultPurifierSerializerCache = null)
     {
         $HTMLPurifierConfig = \HTMLPurifier_Config::createDefault();
-        // Cache for the serializer defaults to inside the HTMLPurifier library
+        // Cache.SerializerPath defaults to Null and sets
+        // the location to inside the vendor HTMLPurifier library
         // under the DefinitionCache/Serializer folder.
         $HTMLPurifierConfig->set('Cache.SerializerPath', $defaultPurifierSerializerCache);
         $this->purifier = new \HTMLPurifier($HTMLPurifierConfig);


### PR DESCRIPTION
- Update TableDiff to initialize purifier with a cache storage location.  Without this, it defaults to the vendor folder.
- Updated the HtmlDiffConfig for the additional parameter.

I think the defaults shouldn't break anything as is.  But if there's a better way than initializing the purifier twice due to the create call I'm listening.