### PR TITLE
Fixed issue with create call on TableDiff object

### DIFF
--- a/lib/Caxy/HtmlDiff/Table/TableDiff.php
+++ b/lib/Caxy/HtmlDiff/Table/TableDiff.php
@@ -67,7 +67,7 @@ class TableDiff extends AbstractDiff
         if (null !== $config) {
             $diff->setConfig($config);
 
-            $this->initPurifier($config->getPurifierCacheLocation());
+            $diff->initPurifier($config->getPurifierCacheLocation());
         }
 
         return $diff;
@@ -100,7 +100,7 @@ class TableDiff extends AbstractDiff
      * @param  null|string $defaultPurifierSerializerCache
      * @return void
      */
-    protected function initPurifier($defaultPurifierSerializerCache = null)
+    public function initPurifier($defaultPurifierSerializerCache = null)
     {
         $HTMLPurifierConfig = \HTMLPurifier_Config::createDefault();
         // Cache.SerializerPath defaults to Null and sets


### PR DESCRIPTION
This slipped through.  ```$this``` is not correct, we should be calling the method on the new object being created.

Also had to update the method call to public from protected.