### PR TITLE
Add function to clear content.

### DIFF
--- a/lib/Caxy/HtmlDiff/HtmlDiff.php
+++ b/lib/Caxy/HtmlDiff/HtmlDiff.php
@@ -86,6 +86,11 @@ class HtmlDiff extends AbstractDiff
         return $this->config->isInsertSpaceInReplace();
     }
 
+    public function clearContent()
+    {
+      $this->content = '';
+    }
+
     /**
      * @return string
      */


### PR DESCRIPTION
I use your library for Drupal with the HTML Diff module (https://www.drupal.org/project/html_diff).
Here it is possible to compare the content of several fields. Without a possibility to clear the content, the diff for the second field also shows the content of the first one, the third field also shows content of no. 1 and 2, and so on (see picture). Therefor I wanted to ask, if it's possible to add a clearing function?

![html_diff-double-content](https://cloud.githubusercontent.com/assets/15780190/14252035/db417d76-fa85-11e5-8e4c-c28486673965.png)
