### PR TITLE
changes the [] arrays to array() as it does not work in php 5.3

### DIFF
--- a/lib/Caxy/HtmlDiff/LcsService.php
+++ b/lib/Caxy/HtmlDiff/LcsService.php
@@ -60,7 +60,7 @@ class LcsService
             }
         }
 
-        $lcs = array_pad([], $m + 1, 0);
+        $lcs = array_pad(array(), $m + 1, 0);
         $this->compileMatches($c, $a, $b, $m, $n, $lcs);
 
         return $lcs;

--- a/lib/Caxy/HtmlDiff/ListDiffLines.php
+++ b/lib/Caxy/HtmlDiff/ListDiffLines.php
@@ -119,7 +119,7 @@ class ListDiffLines extends AbstractDiff
         $oldLength = count($oldListText);
         $newLength = count($newListText);
 
-        $operations = [];
+        $operations = array();
         $currentLineInOld = 0;
         $currentLineInNew = 0;
         $lcsMatches[$oldLength + 1] = $newLength + 1;


### PR DESCRIPTION
In php 5.3 you can not use []. This changes the two times [] is used to array() to make it work with 5.3.

"As of PHP 5.4 you can also use the short array syntax, which replaces array() with []."