### PR TITLE
Fixed warnings "count(): Parameter must be an array...

### DIFF
--- a/lib/Caxy/HtmlDiff/AbstractDiff.php
+++ b/lib/Caxy/HtmlDiff/AbstractDiff.php
@@ -474,6 +474,7 @@ abstract class AbstractDiff
         $mode = 'character';
         $current_word = '';
         $words = array();
+        $keepNewLines = $this->getConfig()->isKeepNewLines();
         foreach ($characterString as $i => $character) {
             switch ($mode) {
                 case 'character':
@@ -488,7 +489,7 @@ abstract class AbstractDiff
                     if ($current_word !== '') {
                         $words[] = $current_word;
                     }
-                    $current_word = preg_replace('/\s+/S', ' ', $character);
+                    $current_word = $keepNewLines ? $character : preg_replace('/\s+/S', ' ', $character);
                     $mode = 'whitespace';
                 } else {
                     if (
@@ -526,7 +527,7 @@ abstract class AbstractDiff
                     $mode = 'tag';
                 } elseif (preg_match("/\s/", $character)) {
                     $current_word .= $character;
-                    $current_word = preg_replace('/\s+/S', ' ', $current_word);
+                    if (!$keepNewLines) $current_word = preg_replace('/\s+/S', ' ', $current_word);
                 } else {
                     if ($current_word != '') {
                         $words[] = $current_word;

--- a/lib/Caxy/HtmlDiff/HtmlDiff.php
+++ b/lib/Caxy/HtmlDiff/HtmlDiff.php
@@ -567,7 +567,7 @@ class HtmlDiff extends AbstractDiff
                     }
                 }
             }
-            if (count($words) == 0 && count($specialCaseTagInjection) == 0) {
+            if (count($words) == 0 && strlen($specialCaseTagInjection) == 0) {
                 break;
             }
             if ($specialCaseTagInjectionIsBefore) {

--- a/lib/Caxy/HtmlDiff/HtmlDiffConfig.php
+++ b/lib/Caxy/HtmlDiff/HtmlDiffConfig.php
@@ -28,6 +28,12 @@ class HtmlDiffConfig
     protected $insertSpaceInReplace = false;
 
     /**
+     * Whether to keep newlines in the diff
+     * @var bool
+     */
+    protected $keepNewLines = false;
+
+    /**
      * @var string
      */
     protected $encoding = 'UTF-8';
@@ -48,6 +54,7 @@ class HtmlDiffConfig
         'i' => '[[REPLACE_EM]]',
         'a' => '[[REPLACE_A]]',
         'img' => '[[REPLACE_IMG]]',
+        'pre' => '[[REPLACE_PRE]]',
     );
 
     /**
@@ -291,6 +298,22 @@ class HtmlDiffConfig
         $this->insertSpaceInReplace = $insertSpaceInReplace;
 
         return $this;
+    }
+
+    /**
+     * @return bool
+     */
+    public function isKeepNewLines()
+    {
+        return $this->keepNewLines;
+    }
+
+    /**
+     * @param bool $keepNewLines
+     */
+    public function setKeepNewLines($keepNewLines)
+    {
+        $this->keepNewLines = $keepNewLines;
     }
 
     /**

--- a/lib/Caxy/HtmlDiff/Match.php
+++ b/lib/Caxy/HtmlDiff/Match.php
@@ -2,7 +2,7 @@
 
 namespace Caxy\HtmlDiff;
 
-class Match
+class Match implements \Countable
 {
     public $startInOld;
     public $startInNew;
@@ -23,5 +23,9 @@ class Match
     public function endInNew()
     {
         return $this->startInNew + $this->size;
+    }
+
+    public function count() {
+        return (int)$this->size;
     }
 }


### PR DESCRIPTION
When running the code under PHP 7.1, I'm getting this:


    Warning: count(): Parameter must be an array or an object that implements Countable in 
    ./vendor/caxy/php-htmldiff/lib/Caxy/HtmlDiff/HtmlDiff.php on line 719

    Warning: count(): Parameter must be an array or an object that implements Countable in 
    ./vendor/caxy/php-htmldiff/lib/Caxy/HtmlDiff/HtmlDiff.php on line 570

There are two reasons:
1) attempt to use count() on an object which doesn't implement Countable
2) attempt to use count() on a string

