### PR TITLE
Resolve PHP 7.3 compatibility issue

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
     "require": {
         "php": ">=5.3.3",
         "ezyang/htmlpurifier": "^4.7",
-        "sunra/php-simple-html-dom-parser": "^1.5"
+        "kub-at/php-simple-html-dom-parser": "^1.7"
     },
     "require-dev": {
         "phpunit/phpunit": "~5.0",

--- a/lib/Caxy/HtmlDiff/ListDiffLines.php
+++ b/lib/Caxy/HtmlDiff/ListDiffLines.php
@@ -3,7 +3,7 @@
 namespace Caxy\HtmlDiff;
 
 use Caxy\HtmlDiff\Strategy\ListItemMatchStrategy;
-use Sunra\PhpSimple\HtmlDomParser;
+use KubAT\PhpSimple\HtmlDomParser;
 
 class ListDiffLines extends AbstractDiff
 {


### PR DESCRIPTION
Change `Sunra\PhpSimple\HtmlDomParser` for `KubAT\PhpSimple\HtmlDomParser` witch is PHP 7.3 compatible.

Tested on system with PHP 7.3 