### PR TITLE
Add previously undocumented config option: setKeepNewLines(false)

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,6 +154,10 @@ $config
         'i'      => '[[REPLACE_I]]',
         'a'      => '[[REPLACE_A]]',
     ))
+    
+    // Sets whether newline characters are kept or removed when `$htmlDiff->build()` is called.
+    // For example, if your content includes <pre> tags, you might want to set this to true.
+    ->setKeepNewLines(false)
 ;
 
 ```


### PR DESCRIPTION
This config item was not listed in README.md previously. It should be known that by default if you use &lt;pre&gt; tags in your content newlines will get stripped out.