### PR TITLE
Reduce release size by excluding demos and tests.

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+/demo export-ignore
+/tests export-ignore


### PR DESCRIPTION
The size of php-htmldiff on disk is 10MB. This may not sound like much, but that could easily make it the single largest package in any given Composer install. This could be easily reduced to <1MB by simply excluding the demos and tests from packaged releases. Anyone who still wants access to those files would still get them by simply cloning from source, but the thousands of other projects simply using this as a library would save a ton of bandwidth and build time. (literally something like 16TB across the [1.6M installs of this project](https://packagist.org/packages/caxy/php-htmldiff/stats).)

This is an increasingly common pattern for Composer libraries, following the [strategy outlined here](https://madewithlove.be/gitattributes/).