### PR TITLE
Added option to disable HTML purifier

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,10 @@ $config
     
     // Pass an instance of \Doctrine\Common\Cache\Cache to cache the calculated diffs.
     ->setCacheProvider(null)
+
+    // Disable the HTML purifier (only do this if you known what you're doing)
+    // This bundle heavily relies on the purified input from ezyang/htmlpurifier
+    ->setPurifierEnabled(true)
     
     // Set the cache directory that HTMLPurifier should use.
     ->setPurifierCacheLocation(null)
@@ -192,7 +196,6 @@ php-htmldiff is available under [GNU General Public License, version 2][gnu]. Se
     * Maybe add abstraction layer for cache + adapter for doctrine cache
 * Make HTML Purifier an optional dependency - possibly use abstraction layer for purifiers so alternatives could be used (or none at all for performance)
 * Expose configuration for HTML Purifier (used in table diffing) - currently only cache dir is configurable through HtmlDiffConfig object
-* Add option to enable using HTML Purifier to purify all input
 * Performance improvements (we have 1 benchmark test, we should probably get more)
     * Algorithm improvements - trimming alike text at start and ends, store nested diff results in memory to re-use (like we do w/ caching)
     * Benchmark using DOMDocument vs. alternatives vs. string parsing

--- a/lib/Caxy/HtmlDiff/AbstractDiff.php
+++ b/lib/Caxy/HtmlDiff/AbstractDiff.php
@@ -66,7 +66,7 @@ abstract class AbstractDiff
     protected $diffCaches = array();
 
     /**
-     * @var \HTMLPurifier
+     * @var \HTMLPurifier|null
      */
     protected $purifier;
 
@@ -154,6 +154,10 @@ abstract class AbstractDiff
      */
     protected function prepare()
     {
+        if (false === $this->config->isPurifierEnabled()) {
+            return;
+        }
+
         $this->initPurifier($this->config->getPurifierCacheLocation());
 
         $this->oldText = $this->purifyHtml($this->oldText);
@@ -403,6 +407,10 @@ abstract class AbstractDiff
      */
     protected function purifyHtml($html)
     {
+        if (null === $this->purifier) {
+            return $html;
+        }
+
         return $this->purifier->purify($html);
     }
 

--- a/lib/Caxy/HtmlDiff/HtmlDiffConfig.php
+++ b/lib/Caxy/HtmlDiff/HtmlDiffConfig.php
@@ -81,6 +81,11 @@ class HtmlDiffConfig
     protected $cacheProvider;
 
     /**
+     * @var bool
+     */
+    protected $purifierEnabled = true;
+
+    /**
      * @var null|string
      */
     protected $purifierCacheLocation = null;
@@ -466,6 +471,18 @@ class HtmlDiffConfig
     public function getCacheProvider()
     {
         return $this->cacheProvider;
+    }
+
+    public function isPurifierEnabled(): bool
+    {
+        return $this->purifierEnabled;
+    }
+
+    public function setPurifierEnabled(bool $purifierEnabled = true): self
+    {
+        $this->purifierEnabled = $purifierEnabled;
+
+        return $this;
     }
 
     /**

--- a/lib/Caxy/HtmlDiff/Table/TableDiff.php
+++ b/lib/Caxy/HtmlDiff/Table/TableDiff.php
@@ -628,7 +628,7 @@ class TableDiff extends AbstractDiff
     {
         $dom = new \DOMDocument();
         $dom->loadHTML(mb_convert_encoding(
-            $this->purifier->purify(mb_convert_encoding($text, $this->config->getEncoding(), mb_detect_encoding($text))),
+            $this->purifyHtml(mb_convert_encoding($text, $this->config->getEncoding(), mb_detect_encoding($text))),
             'HTML-ENTITIES',
             $this->config->getEncoding()
         ));


### PR DESCRIPTION
Not much more to say: I already feed the differ purified HTML for my use case, so I do not another pass. Also, it broke some of my tags (`<figure>` & `<figcaption>` for example).