### PR TITLE
Check object is actual array before calling count to prevent warnings

### DIFF
--- a/lib/Caxy/HtmlDiff/HtmlDiff.php
+++ b/lib/Caxy/HtmlDiff/HtmlDiff.php
@@ -534,7 +534,7 @@ class HtmlDiff extends AbstractDiff
     protected function insertTag($tag, $cssClass, &$words)
     {
         while (true) {
-            if (!is_countable($words) || count($words) == 0) {
+            if (!is_array($words) || count($words) == 0) {
                 break;
             }
 
@@ -567,7 +567,7 @@ class HtmlDiff extends AbstractDiff
                     }
                 }
             }
-            if ((!is_countable($words) || count($words) == 0) && $this->stringUtil->strlen($specialCaseTagInjection) == 0) {
+            if ((!is_array($words) || count($words) == 0) && $this->stringUtil->strlen($specialCaseTagInjection) == 0) {
                 break;
             }
             if ($specialCaseTagInjectionIsBefore) {

--- a/lib/Caxy/HtmlDiff/HtmlDiff.php
+++ b/lib/Caxy/HtmlDiff/HtmlDiff.php
@@ -534,7 +534,7 @@ class HtmlDiff extends AbstractDiff
     protected function insertTag($tag, $cssClass, &$words)
     {
         while (true) {
-            if (count($words) == 0) {
+            if (!is_countable($words) || count($words) == 0) {
                 break;
             }
 
@@ -567,7 +567,7 @@ class HtmlDiff extends AbstractDiff
                     }
                 }
             }
-            if (count($words) == 0 && $this->stringUtil->strlen($specialCaseTagInjection) == 0) {
+            if ((!is_countable($words) || count($words) == 0) && $this->stringUtil->strlen($specialCaseTagInjection) == 0) {
                 break;
             }
             if ($specialCaseTagInjectionIsBefore) {


### PR DESCRIPTION
As of PHP 7.2 if you pass count(null) it'll emit a warning of `Parameter must be an array or an object that implements Countable in … ` This makes sure that the `$words` is actually an array and not null, so it is in fact countable. 