### PR TITLE
Fix reserved keyword match in PHP 8.0

### DIFF
--- a/lib/Caxy/HtmlDiff/HtmlDiff.php
+++ b/lib/Caxy/HtmlDiff/HtmlDiff.php
@@ -696,7 +696,7 @@ class HtmlDiff extends AbstractDiff
         $operations = array();
 
         $matches   = $this->matchingBlocks();
-        $matches[] = new Match(count($this->oldWords), count($this->newWords), 0);
+        $matches[] = new Match_(count($this->oldWords), count($this->newWords), 0);
 
         foreach ($matches as $match) {
             $matchStartsAtCurrentPositionInOld = ($positionInOld === $match->startInOld);
@@ -728,7 +728,7 @@ class HtmlDiff extends AbstractDiff
     }
 
     /**
-     * @return Match[]
+     * @return Match_[]
      */
     protected function matchingBlocks()
     {
@@ -784,7 +784,7 @@ class HtmlDiff extends AbstractDiff
      * @param int $startInNew
      * @param int $endInNew
      *
-     * @return Match|null
+     * @return Match_|null
      */
     protected function findMatch($startInOld, $endInOld, $startInNew, $endInNew)
     {
@@ -837,7 +837,7 @@ class HtmlDiff extends AbstractDiff
                 !$this->isOnlyWhitespace($this->array_slice_cached($this->oldWords, $bestMatchInOld, $bestMatchSize))
             )
         ) {
-            return new Match($bestMatchInOld, $bestMatchInNew, $bestMatchSize);
+            return new Match_($bestMatchInOld, $bestMatchInNew, $bestMatchSize);
         }
 
         return null;

--- a/lib/Caxy/HtmlDiff/Match_.php
+++ b/lib/Caxy/HtmlDiff/Match_.php
@@ -2,7 +2,7 @@
 
 namespace Caxy\HtmlDiff;
 
-class Match implements \Countable
+class Match_ implements \Countable
 {
     public $startInOld;
     public $startInNew;


### PR DESCRIPTION
Note this currently breaks Psalm/PHPStan, even though PHP 8.0 is still months away from releasing.