### PR TITLE
Performance enhancements. Rebuild the word parser and replace the whitespace checker in the match finder.

### DIFF
--- a/lib/Caxy/HtmlDiff/AbstractDiff.php
+++ b/lib/Caxy/HtmlDiff/AbstractDiff.php
@@ -398,8 +398,8 @@ abstract class AbstractDiff
 
     protected function splitInputsToWords()
     {
-        $this->setOldWords($this->convertHtmlToListOfWords($this->explode($this->oldText)));
-        $this->setNewWords($this->convertHtmlToListOfWords($this->explode($this->newText)));
+        $this->setOldWords($this->convertHtmlToListOfWords($this->oldText));
+        $this->setNewWords($this->convertHtmlToListOfWords($this->newText));
     }
 
     /**
@@ -421,146 +421,84 @@ abstract class AbstractDiff
     }
 
     /**
-     * @param string $text
-     *
-     * @return bool
+     * @return string[]
      */
-    protected function isPartOfWord($text)
+    protected function convertHtmlToListOfWords(string $text) : array
     {
-        return $this->ctypeAlphanumUnicode(str_replace($this->config->getSpecialCaseChars(), '', $text));
-    }
+        $words            = [];
+        $sentencesAndTags = [];
 
-    /**
-     * @param array $characterString
-     *
-     * @return array
-     */
-    protected function convertHtmlToListOfWords($characterString)
-    {
-        $mode = 'character';
-        $current_word = '';
-        $words = array();
-        $keepNewLines = $this->getConfig()->isKeepNewLines();
-        foreach ($characterString as $i => $character) {
-            switch ($mode) {
-                case 'character':
-                if ($this->isStartOfTag($character)) {
-                    if ($current_word != '') {
-                        $words[] = $current_word;
-                    }
+        $specialCharacters = '';
 
-                    $current_word = '<';
-                    $mode = 'tag';
-                } elseif (preg_match("/\s/u", $character)) {
-                    if ($current_word !== '') {
-                        $words[] = $current_word;
-                    }
-                    $current_word = $keepNewLines ? $character : preg_replace('/\s+/Su', ' ', $character);
-                    $mode = 'whitespace';
-                } else {
-                    if (
-                        (($this->ctypeAlphanumUnicode($character) === true) && ($this->stringUtil->strlen($current_word) === 0 || $this->isPartOfWord($current_word))) ||
-                        (in_array($character, $this->config->getSpecialCaseChars()) && isset($characterString[$i + 1]) && $this->isPartOfWord($characterString[$i + 1]))
-                    ) {
-                        $current_word .= $character;
-                    } else {
-                        $words[] = $current_word;
-                        $current_word = $character;
-                    }
-                }
-                break;
-                case 'tag' :
-                if ($this->isEndOfTag($character)) {
-                    $current_word .= '>';
-                    $words[] = $current_word;
-                    $current_word = '';
-
-                    if (!preg_match('[^\s]u', $character)) {
-                        $mode = 'whitespace';
-                    } else {
-                        $mode = 'character';
-                    }
-                } else {
-                    $current_word .= $character;
-                }
-                break;
-                case 'whitespace':
-                if ($this->isStartOfTag($character)) {
-                    if ($current_word !== '') {
-                        $words[] = $current_word;
-                    }
-                    $current_word = '<';
-                    $mode = 'tag';
-                } elseif (preg_match("/\s/u", $character)) {
-                    $current_word .= $character;
-                    if (!$keepNewLines) $current_word = preg_replace('/\s+/Su', ' ', $current_word);
-                } else {
-                    if ($current_word != '') {
-                        $words[] = $current_word;
-                    }
-                    $current_word = $character;
-                    $mode = 'character';
-                }
-                break;
-                default:
-                break;
-            }
+        foreach ($this->config->getSpecialCaseChars() as $char) {
+            $specialCharacters .= '\\' . $char;
         }
-        if ($current_word != '') {
-            $words[] = $current_word;
+
+        // Normalize no-break-spaces to regular spaces
+        $text = str_replace("\xc2\xa0", ' ', $text);
+
+        preg_match_all('/<.+?>|[^<]+/mu', $text, $sentencesAndTags, PREG_SPLIT_NO_EMPTY);
+
+        foreach ($sentencesAndTags[0] as $sentenceOrHtmlTag) {
+            if ($sentenceOrHtmlTag === '') {
+                continue;
+            }
+
+            if ($sentenceOrHtmlTag[0] === '<') {
+                $words[] = $sentenceOrHtmlTag;
+
+                continue;
+            }
+
+            $sentenceOrHtmlTag = $this->normalizeWhitespaceInHtmlSentence($sentenceOrHtmlTag);
+
+            $sentenceSplitIntoWords = [];
+
+            // This regex splits up every word by separating it at every non alpha-numerical, it allows the specialChars
+            // in the middle of a word, but not at the beginning or the end of a word.
+            // Split regex compiles to this (in default config case);
+            // /\s|[\.\,\(\)\']|[a-zA-Z0-9\.\,\(\)'\pL]+[a-zA-Z0-9\pL]|[^\s]/mu
+            $regex = sprintf('/\s|[%s]|[a-zA-Z0-9%s\pL]+[a-zA-Z0-9\pL]|[^\s]/mu', $specialCharacters, $specialCharacters);
+
+            preg_match_all(
+                $regex,
+                $sentenceOrHtmlTag . ' ', // Inject a space at the end to make sure the last word is found by having a space behind it.
+                $sentenceSplitIntoWords,
+                PREG_SPLIT_NO_EMPTY
+            );
+
+            // Remove the last space, since that was added by us for the regex matcher
+            array_pop($sentenceSplitIntoWords[0]);
+
+            foreach ($sentenceSplitIntoWords[0] as $word) {
+                $words[] = $word;
+            }
         }
 
         return $words;
     }
 
-    /**
-     * @param string $val
-     *
-     * @return bool
-     */
-    protected function isStartOfTag($val)
+    protected function normalizeWhitespaceInHtmlSentence(string $sentence) : string
     {
-        return $val === '<';
-    }
+        if ($this->config->isKeepNewLines() === true) {
+            return $sentence;
+        }
 
-    /**
-     * @param string $val
-     *
-     * @return bool
-     */
-    protected function isEndOfTag($val)
-    {
-        return $val === '>';
-    }
+        $sentence = preg_replace('/\s\s+|\r+|\n+|\r\n+/', ' ', $sentence);
 
-    /**
-     * @param string $value
-     *
-     * @return bool
-     */
-    protected function isWhiteSpace($value)
-    {
-        return !preg_match('[^\s]u', $value);
-    }
 
-    /**
-     * @param string $value
-     *
-     * @return array
-     */
-    protected function explode($value)
-    {
-        // as suggested by @onassar
-        return preg_split('//u', $value, -1, PREG_SPLIT_NO_EMPTY);
-    }
+        $sentenceLength = $this->stringUtil->strlen($sentence);
+        $firstCharacter = $this->stringUtil->substr($sentence, 0, 1);
+        $lastCharacter  = $this->stringUtil->substr($sentence, $sentenceLength -1, 1);
 
-    /**
-     * @param string $str
-     *
-     * @return bool
-     */
-    protected function ctypeAlphanumUnicode($str)
-    {
-        return preg_match("/^[a-zA-Z0-9\pL]+$/u", $str) === 1;
+        if ($firstCharacter === ' ' || $firstCharacter === "\r" || $firstCharacter === "\n") {
+            $sentence = ' ' . ltrim($sentence);
+        }
+
+        if ($sentenceLength > 1 && ($lastCharacter === ' ' || $lastCharacter === "\r" || $lastCharacter === "\n")) {
+            $sentence = rtrim($sentence) . ' ';
+        }
+
+        return $sentence;
     }
 }

--- a/lib/Caxy/HtmlDiff/HtmlDiff.php
+++ b/lib/Caxy/HtmlDiff/HtmlDiff.php
@@ -13,14 +13,7 @@ class HtmlDiff extends AbstractDiff
      * @var array
      */
     protected $wordIndices;
-    /**
-     * @var array
-     */
-    protected $oldTables;
-    /**
-     * @var array
-     */
-    protected $newTables;
+
     /**
      * @var array
      */

--- a/lib/Caxy/HtmlDiff/HtmlDiff.php
+++ b/lib/Caxy/HtmlDiff/HtmlDiff.php
@@ -244,19 +244,19 @@ class HtmlDiff extends AbstractDiff
     {
         switch ($operation->action) {
             case 'equal' :
-            $this->processEqualOperation($operation);
-            break;
+                $this->processEqualOperation($operation);
+                break;
             case 'delete' :
-            $this->processDeleteOperation($operation, 'diffdel');
-            break;
+                $this->processDeleteOperation($operation, 'diffdel');
+                break;
             case 'insert' :
-            $this->processInsertOperation($operation, 'diffins');
-            break;
+                $this->processInsertOperation($operation, 'diffins');
+                break;
             case 'replace':
-            $this->processReplaceOperation($operation);
-            break;
+                $this->processReplaceOperation($operation);
+                break;
             default:
-            break;
+                break;
         }
     }
 

--- a/lib/Caxy/HtmlDiff/HtmlDiff.php
+++ b/lib/Caxy/HtmlDiff/HtmlDiff.php
@@ -734,26 +734,24 @@ class HtmlDiff extends AbstractDiff
     }
 
     /**
-     * @param int   $startInOld
-     * @param int   $endInOld
-     * @param int   $startInNew
-     * @param int   $endInNew
-     * @param array $matchingBlocks
+     * @param MatchingBlock[] $matchingBlocks
      */
-    protected function findMatchingBlocks($startInOld, $endInOld, $startInNew, $endInNew, &$matchingBlocks)
+    protected function findMatchingBlocks(int $startInOld, int $endInOld, int $startInNew, int $endInNew, array &$matchingBlocks) : void
     {
         $match = $this->findMatch($startInOld, $endInOld, $startInNew, $endInNew);
 
-        if ($match !== null) {
-            if ($startInOld < $match->startInOld && $startInNew < $match->startInNew) {
-                $this->findMatchingBlocks($startInOld, $match->startInOld, $startInNew, $match->startInNew, $matchingBlocks);
-            }
+        if ($match === null) {
+            return;
+        }
 
-            $matchingBlocks[] = $match;
+        if ($startInOld < $match->startInOld && $startInNew < $match->startInNew) {
+            $this->findMatchingBlocks($startInOld, $match->startInOld, $startInNew, $match->startInNew, $matchingBlocks);
+        }
 
-            if ($match->endInOld() < $endInOld && $match->endInNew() < $endInNew) {
-                $this->findMatchingBlocks($match->endInOld(), $endInOld, $match->endInNew(), $endInNew, $matchingBlocks);
-            }
+        $matchingBlocks[] = $match;
+
+        if ($match->endInOld() < $endInOld && $match->endInNew() < $endInNew) {
+            $this->findMatchingBlocks($match->endInOld(), $endInOld, $match->endInNew(), $endInNew, $matchingBlocks);
         }
     }
 
@@ -766,70 +764,71 @@ class HtmlDiff extends AbstractDiff
     {
         $space = $this->stringUtil->strpos($word, ' ', 1);
 
-        if ($space) {
+        if ($space > 0) {
             return '<' . $this->stringUtil->substr($word, 1, $space) . '>';
         }
 
         return trim($word, '<>');
     }
 
-    /**
-     * @param int $startInOld
-     * @param int $endInOld
-     * @param int $startInNew
-     * @param int $endInNew
-     *
-     * @return MatchingBlock|null
-     */
-    protected function findMatch($startInOld, $endInOld, $startInNew, $endInNew)
+    protected function findMatch(int $startInOld, int $endInOld, int $startInNew, int $endInNew) : ?MatchingBlock
     {
         $groupDiffs     = $this->isGroupDiffs();
         $bestMatchInOld = $startInOld;
         $bestMatchInNew = $startInNew;
         $bestMatchSize = 0;
-        $matchLengthAt = array();
+        $matchLengthAt = [];
 
         for ($indexInOld = $startInOld; $indexInOld < $endInOld; ++$indexInOld) {
-            $newMatchLengthAt = array();
+            $newMatchLengthAt = [];
+
             $index = $this->oldWords[ $indexInOld ];
-            if ($this->isTag($index)) {
+
+            if ($this->isTag($index) === true) {
                 $index = $this->stripTagAttributes($index);
             }
-            if (!isset($this->wordIndices[ $index ])) {
+
+            if (isset($this->wordIndices[$index]) === false) {
                 $matchLengthAt = $newMatchLengthAt;
+
                 continue;
             }
-            foreach ($this->wordIndices[ $index ] as $indexInNew) {
+
+            foreach ($this->wordIndices[$index] as $indexInNew) {
                 if ($indexInNew < $startInNew) {
                     continue;
                 }
+
                 if ($indexInNew >= $endInNew) {
                     break;
                 }
 
-                $newMatchLength = (isset($matchLengthAt[ $indexInNew - 1 ]) ? $matchLengthAt[ $indexInNew - 1 ] : 0) + 1;
-                $newMatchLengthAt[ $indexInNew ] = $newMatchLength;
+                $newMatchLength =
+                    (isset($matchLengthAt[$indexInNew - 1]) === true ? ($matchLengthAt[$indexInNew - 1] + 1) : 1);
+
+                $newMatchLengthAt[$indexInNew] = $newMatchLength;
 
                 if ($newMatchLength > $bestMatchSize ||
                     (
-                        $groupDiffs &&
+                        $groupDiffs === true &&
                         $bestMatchSize > 0 &&
-                        $this->isOnlyWhitespace($this->array_slice_cached($this->oldWords, $bestMatchInOld, $bestMatchSize))
+                        $this->oldTextIsOnlyWhitespace($bestMatchInOld, $bestMatchSize) === true
                     )
                 ) {
                     $bestMatchInOld = $indexInOld - $newMatchLength + 1;
                     $bestMatchInNew = $indexInNew - $newMatchLength + 1;
-                    $bestMatchSize = $newMatchLength;
+                    $bestMatchSize  = $newMatchLength;
                 }
             }
+
             $matchLengthAt = $newMatchLengthAt;
         }
 
         // Skip match if none found or match consists only of whitespace
         if ($bestMatchSize !== 0 &&
             (
-                !$groupDiffs ||
-                !$this->isOnlyWhitespace($this->array_slice_cached($this->oldWords, $bestMatchInOld, $bestMatchSize))
+                $groupDiffs === false ||
+                $this->oldTextIsOnlyWhitespace($bestMatchInOld, $bestMatchSize) === false
             )
         ) {
             return new MatchingBlock($bestMatchInOld, $bestMatchInNew, $bestMatchSize);
@@ -838,40 +837,16 @@ class HtmlDiff extends AbstractDiff
         return null;
     }
 
-    /**
-     * @param string $str
-     *
-     * @return bool
-     */
-    protected function isOnlyWhitespace($str)
+    protected function oldTextIsOnlyWhitespace(int $startingAtWord, int $wordCount) : bool
     {
-        //  Slightly faster then using preg_match
-        return $str !== '' && trim($str) === '';
-    }
+        $isWhitespace = true;
 
-    /**
-     * Special array_slice function that caches its last request.
-     *
-     * The diff algorithm seems to request the same information many times in a row.
-     * by returning the previous answer the algorithm preforms way faster.
-     *
-     * The result is a string instead of an array, this way we safe on the amount of
-     * memory intensive implode() calls.
-     *
-     * @param array         &$array
-     * @param integer       $offset
-     * @param integer|null  $length
-     *
-     * @return string
-     */
-    protected function array_slice_cached(&$array, $offset, $length = null)
-    {
-        static $lastOffset = null;
-        static $lastLength = null;
-        static $cache      = null;
+        // oldTextIsWhitespace get called consecutively by findMatch, with the same parameters.
+        // by caching the previous result, we speed up the algorithm by more then 50%
+        static $lastStartingWordOffset = null;
+        static $lastWordCount          = null;
+        static $cache                  = null;
 
-        // PHP has no support for by-reference comparing.
-        // to prevent false positive hits, reset the cache when the oldWords or newWords is changed.
         if ($this->resetCache === true) {
             $cache = null;
 
@@ -880,16 +855,28 @@ class HtmlDiff extends AbstractDiff
 
         if (
             $cache !== null &&
-            $lastLength === $length &&
-            $lastOffset === $offset
+            $lastWordCount === $wordCount &&
+            $lastStartingWordOffset === $startingAtWord
         ) { // Hit
             return $cache;
         } // Miss
 
-        $lastOffset = $offset;
-        $lastLength = $length;
+        for ($index = $startingAtWord; $index < ($startingAtWord + $wordCount); $index++) {
+            // Assigning the oldWord to a variable is slightly faster then searching by reference twice
+            // in the if statement
+            $oldWord = $this->oldWords[$index];
 
-        $cache = implode('', array_slice($array, $offset, $length));
+            if ($oldWord !== '' && trim($oldWord) !== '') {
+                $isWhitespace = false;
+
+                break;
+            }
+        }
+
+        $lastWordCount          = $wordCount;
+        $lastStartingWordOffset = $startingAtWord;
+
+        $cache = $isWhitespace;
 
         return $cache;
     }

--- a/lib/Caxy/HtmlDiff/HtmlDiff.php
+++ b/lib/Caxy/HtmlDiff/HtmlDiff.php
@@ -18,6 +18,7 @@ class HtmlDiff extends AbstractDiff
      * @var array
      */
     protected $newIsolatedDiffTags;
+
     /**
      * @var array
      */
@@ -116,18 +117,20 @@ class HtmlDiff extends AbstractDiff
         return $this->content;
     }
 
-    protected function indexNewWords()
+    protected function indexNewWords() : void
     {
-        $this->wordIndices = array();
+        $this->wordIndices = [];
+
         foreach ($this->newWords as $i => $word) {
-            if ($this->isTag($word)) {
+            if ($this->isTag($word) === true) {
                 $word = $this->stripTagAttributes($word);
             }
-            if (isset($this->wordIndices[ $word ])) {
-                $this->wordIndices[ $word ][] = $i;
-            } else {
-                $this->wordIndices[ $word ] = array($i);
+
+            if (isset($this->wordIndices[$word]) === false) {
+                $this->wordIndices[$word] = [];
             }
+
+            $this->wordIndices[$word][] = $i;
         }
     }
 

--- a/lib/Caxy/HtmlDiff/HtmlDiffConfig.php
+++ b/lib/Caxy/HtmlDiff/HtmlDiffConfig.php
@@ -13,7 +13,7 @@ class HtmlDiffConfig
     protected $specialCaseTags = array('strong', 'b', 'i', 'big', 'small', 'u', 'sub', 'sup', 'strike', 's', 'p');
 
     /**
-     * @var array
+     * @var string[]
      */
     protected $specialCaseChars = array('.', ',', '(', ')', '\'');
 
@@ -126,18 +126,12 @@ class HtmlDiffConfig
         return $this;
     }
 
-    /**
-     * @param array $chars
-     */
     public function setSpecialCaseChars(array $chars)
     {
         $this->specialCaseChars = $chars;
     }
 
-    /**
-     * @return array|null
-     */
-    public function getSpecialCaseChars()
+    public function getSpecialCaseChars() : array
     {
         return $this->specialCaseChars;
     }


### PR DESCRIPTION
## Description

While investigating if I could improve the performance for this PR https://github.com/caxy/php-htmldiff/issues/101 I stumbled upon two bottlenecks.

# 1. The html to word parser was a big for loop that walked over every character individually

The code was really complex, and hard to comprehend. It was  a huge loop with loads of code-flow inside that was affected by what character was being processed, what character was processed previously, and what process was comming up.

I replace it by mostly regex parsing that does the heavy lifting, speeding this method up by 98%

- Old
![image](https://user-images.githubusercontent.com/1238070/113490026-f719d480-94c7-11eb-8d8f-d5e397bb6cbf.png)

- New
![image](https://user-images.githubusercontent.com/1238070/113490039-039e2d00-94c8-11eb-989d-7c8d8480ca7c.png)


# 2. Whitespace checking was resource intensive

While finding blocks we have todo a whitespace check of part of the old sentence, this is done loads of times. This is done by referencing the oldWords array, and temporarily making a string from part of that array, and then checking if that string is only whitespace.

A couple of years ago I already added caching here, to speed up the algorithm allot, but I took some more time to investigate if this can be improved further.

I have replaced this by a loop that iterates over the part of the sentence item by item, and when one of the items is not a space (usually the first item), it immediately reports false and caching the result, speeding up the algorithm in some cases by up to 50%

- Old
![image](https://user-images.githubusercontent.com/1238070/113492948-998f8300-94db-11eb-90ca-dd317f3388b9.png)

- New
![image](https://user-images.githubusercontent.com/1238070/113492972-cc397b80-94db-11eb-96ae-f093a2d75f29.png)
