### PR TITLE
Remove special-case-tags feature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,26 @@
 # Change Log
 
+## [v0.1.14](https://github.com/caxy/php-htmldiff/tree/v0.1.13) (2022-01-19)
+[Full Changelog](https://github.com/caxy/php-htmldiff/compare/v0.1.13...v0.1.14)
+
+### Changes:
+
+This release mainly removed everything that is related to the concept of special-case-tags. This was adopted from the
+original library by rashid2538 that this fork is based on. 
+
+The feature tried to wrap the special tags in an extra `<ins / del class='mod'>` tag.
+However, this never really worked properly (the closing tag was not always added to the diff output) and usually ended up crippling the HTML.
+
+Given the feature never really worked, and there is no clear use-case for it, I decided to remove it and fix
+issue 106 and issue 69 in the process where it was sometimes impossible to diff html that contained these special tags or unexpected extra tags got added to the output.
+
+In case you really needed this feature, please open an issue explaining your use-case, in that case this decision can be revisited.
+
+- Deprecated all setSpecialCaseTags() config calls. There is no replacement, but the current expectation is that nobody ever used these calls anyway.
+- Fixed Issue 106 / 69 by removing special-case-tags from the codebase
+- Reduced the CRAP score of insertTag() by allot
+
+
 ## [v0.1.13](https://github.com/caxy/php-htmldiff/tree/v0.1.13) (2021-09-27)
 [Full Changelog](https://github.com/caxy/php-htmldiff/compare/v0.1.12...v0.1.13)
 

--- a/README.md
+++ b/README.md
@@ -148,10 +148,7 @@ $config
     
     // List of characters to consider part of a single word when in the middle of text.
     ->setSpecialCaseChars(array('.', ',', '(', ')', '\''))
-    
-    // List of tags to treat as special case tags.
-    ->setSpecialCaseTags(array('strong', 'b', 'i', 'big', 'small', 'u', 'sub', 'sup', 'strike', 's', 'p'))
-    
+        
     // List of tags (and their replacement strings) to be diffed in isolation.
     ->setIsolatedDiffTags(array(
         'ol'     => '[[REPLACE_ORDERED_LIST]]',

--- a/lib/Caxy/HtmlDiff/AbstractDiff.php
+++ b/lib/Caxy/HtmlDiff/AbstractDiff.php
@@ -94,7 +94,7 @@ abstract class AbstractDiff
      * @param string     $oldText
      * @param string     $newText
      * @param string     $encoding
-     * @param null|array $specialCaseTags
+     * @param null|array $specialCaseTags (this does nothing, it is just here to keep the interface compatible)
      * @param null|bool  $groupDiffs
      */
     public function __construct($oldText, $newText, $encoding = 'UTF-8', $specialCaseTags = null, $groupDiffs = null)
@@ -102,10 +102,6 @@ abstract class AbstractDiff
         $this->stringUtil = new MbStringUtil($oldText, $newText);
 
         $this->setConfig(HtmlDiffConfig::create()->setEncoding($encoding));
-
-        if ($specialCaseTags !== null) {
-            $this->config->setSpecialCaseTags($specialCaseTags);
-        }
 
         if ($groupDiffs !== null) {
             $this->config->setGroupDiffs($groupDiffs);
@@ -313,7 +309,7 @@ abstract class AbstractDiff
      */
     public function getSpecialCaseTags()
     {
-        return $this->config->getSpecialCaseTags();
+        return null;
     }
 
     /**

--- a/lib/Caxy/HtmlDiff/HtmlDiff.php
+++ b/lib/Caxy/HtmlDiff/HtmlDiff.php
@@ -452,7 +452,7 @@ class HtmlDiff extends AbstractDiff
      */
     protected function isListPlaceholder($text)
     {
-        return $this->isPlaceholderType($text, array('ol', 'dl', 'ul'));
+        return $this->isPlaceholderType($text, ['ol', 'dl', 'ul']);
     }
 
     /**
@@ -478,26 +478,26 @@ class HtmlDiff extends AbstractDiff
     /**
      * @param string       $text
      * @param array|string $types
-     * @param bool         $strict
      *
      * @return bool
      */
-    protected function isPlaceholderType($text, $types, $strict = true)
+    protected function isPlaceholderType($text, $types)
     {
-        if (!is_array($types)) {
-            $types = array($types);
+        if (is_array($types) === false) {
+            $types = [$types];
         }
 
-        $criteria = array();
+        $criteria = [];
+
         foreach ($types as $type) {
-            if ($this->config->isIsolatedDiffTag($type)) {
+            if ($this->config->isIsolatedDiffTag($type) === true) {
                 $criteria[] = $this->config->getIsolatedDiffTagPlaceholder($type);
             } else {
                 $criteria[] = $type;
             }
         }
 
-        return in_array($text, $criteria, $strict);
+        return in_array($text, $criteria, true);
     }
 
     /**

--- a/lib/Caxy/HtmlDiff/HtmlDiffConfig.php
+++ b/lib/Caxy/HtmlDiff/HtmlDiffConfig.php
@@ -8,11 +8,6 @@ namespace Caxy\HtmlDiff;
 class HtmlDiffConfig
 {
     /**
-     * @var array
-     */
-    protected $specialCaseTags = array('strong', 'b', 'i', 'big', 'small', 'u', 'sub', 'sup', 'strike', 's', 'p');
-
-    /**
      * @var string[]
      */
     protected $specialCaseChars = array('.', ',', '(', ')', '\'');
@@ -61,14 +56,6 @@ class HtmlDiffConfig
      * @var int
      */
     protected $matchThreshold = 80;
-    /**
-     * @var array
-     */
-    protected $specialCaseOpeningTags = array();
-    /**
-     * @var array
-     */
-    protected $specialCaseClosingTags = array();
 
     /**
      * @var bool
@@ -103,7 +90,6 @@ class HtmlDiffConfig
      */
     public function __construct()
     {
-        $this->setSpecialCaseTags($this->specialCaseTags);
     }
 
     /**
@@ -166,77 +152,49 @@ class HtmlDiffConfig
     }
 
     /**
+     * @deprecated This feature never properly worked, and is removed in version 0.1.14
+     *
      * @param array $tags
      *
      * @return $this
      */
     public function setSpecialCaseTags(array $tags = array())
     {
-        $this->specialCaseTags = $tags;
-        $this->specialCaseOpeningTags = array();
-        $this->specialCaseClosingTags = array();
-
-        foreach ($this->specialCaseTags as $tag) {
-            $this->addSpecialCaseTag($tag);
-        }
-
         return $this;
     }
 
     /**
+     * @deprecated This feature never properly worked, and is removed in version 0.1.14
+     *
      * @param string $tag
      *
      * @return $this
      */
     public function addSpecialCaseTag($tag)
     {
-        if (!in_array($tag, $this->specialCaseTags)) {
-            $this->specialCaseTags[] = $tag;
-        }
-
-        $opening = $this->getOpeningTag($tag);
-        $closing = $this->getClosingTag($tag);
-
-        if (!in_array($opening, $this->specialCaseOpeningTags)) {
-            $this->specialCaseOpeningTags[] = $opening;
-        }
-        if (!in_array($closing, $this->specialCaseClosingTags)) {
-            $this->specialCaseClosingTags[] = $closing;
-        }
-
         return $this;
     }
 
     /**
+     * @deprecated This feature never properly worked, and is removed in version 0.1.14
+     *
      * @param string $tag
      *
      * @return $this
      */
     public function removeSpecialCaseTag($tag)
     {
-        if (($key = array_search($tag, $this->specialCaseTags)) !== false) {
-            unset($this->specialCaseTags[$key]);
-
-            $opening = $this->getOpeningTag($tag);
-            $closing = $this->getClosingTag($tag);
-
-            if (($key = array_search($opening, $this->specialCaseOpeningTags)) !== false) {
-                unset($this->specialCaseOpeningTags[$key]);
-            }
-            if (($key = array_search($closing, $this->specialCaseClosingTags)) !== false) {
-                unset($this->specialCaseClosingTags[$key]);
-            }
-        }
-
         return $this;
     }
 
     /**
-     * @return array|null
+     * @deprecated This feature never properly worked, and is removed in version 0.1.14
+     *
+     * @return null
      */
     public function getSpecialCaseTags()
     {
-        return $this->specialCaseTags;
+        return null;
     }
 
     /**
@@ -409,22 +367,6 @@ class HtmlDiffConfig
     public function getIsolatedDiffTagPlaceholder($tag)
     {
         return $this->isIsolatedDiffTag($tag) ? $this->isolatedDiffTags[$tag] : null;
-    }
-
-    /**
-     * @return array
-     */
-    public function getSpecialCaseOpeningTags()
-    {
-        return $this->specialCaseOpeningTags;
-    }
-
-    /**
-     * @return array
-     */
-    public function getSpecialCaseClosingTags()
-    {
-        return $this->specialCaseClosingTags;
     }
 
     /**


### PR DESCRIPTION
# Description

This was adopted from the original library by rashid2538 that this fork is based on. 

The feature tried to wrap the special tags in `<ins class='mod'>` tags. However, this never really worked properly and usually ended up crippling the HTML.

Given the feature never really worked, and I can not think of any use-case for it anyway, I decided to remove it and fix
[Issue 106](https://github.com/caxy/php-htmldiff/issues/106) where it was sometimes impossible to diff HTML that contained these special tags.

This also simplifies the code in `insertTag()`

I understand this chance can be a bit controversial, but I would argue it is for the best, none of the maintainers of this library intentionally added it, and its pretty vague what it is even used for.

In case you have a use-case for this, please open an issue explaining why in that case this decision can be revisited

# Related GitHub Issue

https://github.com/caxy/php-htmldiff/issues/106

Likely also this bugreport: https://github.com/caxy/php-htmldiff/issues/69