### PR TITLE
Add spaceMatching setting that matches all spaces

### DIFF
--- a/lib/Caxy/HtmlDiff/HtmlDiff.php
+++ b/lib/Caxy/HtmlDiff/HtmlDiff.php
@@ -584,7 +584,7 @@ class HtmlDiff extends AbstractDiff
 
     protected function wrapText(string $text, string $tagName, string $cssClass) : string
     {
-        if (trim($text) === '') {
+        if (!$this->config->isSpaceMatching() && trim($text) === '') {
             return '';
         }
 

--- a/lib/Caxy/HtmlDiff/HtmlDiffConfig.php
+++ b/lib/Caxy/HtmlDiff/HtmlDiffConfig.php
@@ -78,6 +78,11 @@ class HtmlDiffConfig
     protected $purifierCacheLocation = null;
 
     /**
+     * @var bool
+     */
+    protected $spaceMatching = false;
+
+    /**
      * @return HtmlDiffConfig
      */
     public static function create()
@@ -439,6 +444,22 @@ class HtmlDiffConfig
     public function getPurifierCacheLocation()
     {
         return $this->purifierCacheLocation;
+    }
+
+    /**
+     * @return bool
+     */
+    public function isSpaceMatching()
+    {
+        return $this->spaceMatching;
+    }
+
+    /**
+     * @param bool $keepNewLines
+     */
+    public function setSpaceMatching($spaceMatching)
+    {
+        $this->spaceMatching = $spaceMatching;
     }
 
     /**

--- a/tests/fixtures/HtmlDiff/simple-list.html
+++ b/tests/fixtures/HtmlDiff/simple-list.html
@@ -1,26 +1,26 @@
 <options></options>
 
 <oldText>
-<ol><li>List item one</li>
-    <li>List item two with subitems:
-        <ul><li>Subitem 1</li>
-            <li>Subitem 2</li>
-            <li>
-                <p>
-                    Hi there<br />
-                <ul><li>B</li>
-                    <li>A</li>
-                    <li>B</li>
-                </ul>
-                </p>
-            </li>
-            <li>
-                <dl><li>Deleted list</li></dl>
-            </li>
-        </ul>
-    </li>
-    <li>Final list item</li>
-</ol>
+    <ol><li>List item one</li>
+        <li>List item two with subitems:
+            <ul><li>Subitem 1</li>
+                <li>Subitem 2</li>
+                <li>
+                    <p>
+                        Hi there<br />
+                    <ul><li>B</li>
+                        <li>A</li>
+                        <li>B</li>
+                    </ul>
+                    </p>
+                </li>
+                <li>
+                    <dl><li>Deleted list</li></dl>
+                </li>
+            </ul>
+        </li>
+        <li>Final list item</li>
+    </ol>
 </oldText>
 
 <newText>

--- a/tests/fixtures/HtmlDiff/spaces-added.html
+++ b/tests/fixtures/HtmlDiff/spaces-added.html
@@ -1,0 +1,6 @@
+<options>
+    <option type="boolean" name="setSpaceMatching" value="true" />
+</options>
+<oldtext>He said:"OK!"</oldtext>
+<newtext>He said: "OK!"</newtext>
+<expected>He said:<ins class="diffins"> </ins>"OK!"</expected>

--- a/tests/fixtures/HtmlDiff/spaces-removed-inside-tag.html
+++ b/tests/fixtures/HtmlDiff/spaces-removed-inside-tag.html
@@ -1,0 +1,6 @@
+<options>
+    <option type="boolean" name="setSpaceMatching" value="true" />
+</options>
+<oldtext><strong>this </strong>is</oldtext>
+<newtext><strong>this</strong>is</newtext>
+<expected><strong>this<del class="diffdel"> </del></strong>is</expected>


### PR DESCRIPTION
This feature tries to provide a fix for #109. It adds a setting `spaceMatching` which can be set to true so spaces aren't ignored at all.

The HTML provided needs to have the meaningless spaces removed beforehand so only the spaces that we want to compare are present. I think this is more easily done by the developer using the library since it knows more about the HTML being used. The case were I want to apply it is for the code generated by a HTML editor that allows a limited set of tags with predefined layout behavior.

I've added some test cases. I haven't tested the code out of these test cases but I think it will serve my purposes well. I've created the PR so it makies its way while I get to implement it on my project. I might have overlooked something and the naming could probably be better so please make suggestions.

Thanks.