### PR TITLE
Correctly match newlines whitin htmltags.

### DIFF
--- a/lib/Caxy/HtmlDiff/AbstractDiff.php
+++ b/lib/Caxy/HtmlDiff/AbstractDiff.php
@@ -433,7 +433,7 @@ abstract class AbstractDiff
         // Normalize no-break-spaces to regular spaces
         $text = str_replace("\xc2\xa0", ' ', $text);
 
-        preg_match_all('/<.+?>|[^<]+/mu', $text, $sentencesAndTags, PREG_SPLIT_NO_EMPTY);
+        preg_match_all('/<[^>]+?>|[^<]+/mu', $text, $sentencesAndTags, PREG_SPLIT_NO_EMPTY);
 
         foreach ($sentencesAndTags[0] as $sentenceOrHtmlTag) {
             if ($sentenceOrHtmlTag === '') {

--- a/lib/Caxy/HtmlDiff/AbstractDiff.php
+++ b/lib/Caxy/HtmlDiff/AbstractDiff.php
@@ -433,7 +433,7 @@ abstract class AbstractDiff
         // Normalize no-break-spaces to regular spaces
         $text = str_replace("\xc2\xa0", ' ', $text);
 
-        preg_match_all('/<[^>]+?>|[^<]+/mu', $text, $sentencesAndTags, PREG_SPLIT_NO_EMPTY);
+        preg_match_all('/<.+?>|[^<]+/mus', $text, $sentencesAndTags, PREG_SPLIT_NO_EMPTY);
 
         foreach ($sentencesAndTags[0] as $sentenceOrHtmlTag) {
             if ($sentenceOrHtmlTag === '') {

--- a/tests/fixtures/HtmlDiff/multiline-tag.html
+++ b/tests/fixtures/HtmlDiff/multiline-tag.html
@@ -1,0 +1,25 @@
+<options>
+    <option type="boolean" name="setKeepNewLines" value="true" />
+    <option type="boolean" name="setPurifierEnabled" value="false" />
+</options>
+
+<oldText>
+	<li
+		attribute="value">
+		value
+	</li>
+</oldText>
+
+<newText>
+	<li
+		attribute="value">
+		newvalue
+	</li>
+</newText>
+
+<expected>
+	<li
+		attribute="value">
+		<del class="diffmod">value</del><ins class="diffmod">newvalue</ins>
+	</li>
+</expected>


### PR DESCRIPTION
When using newlines within htmltags the regular expression used doesn't account for newlines, this pull request aims to fix this issue.