### PR TITLE
fix(php 8.4): Add explicit nullable type

### DIFF
--- a/lib/Caxy/HtmlDiff/HtmlDiff.php
+++ b/lib/Caxy/HtmlDiff/HtmlDiff.php
@@ -31,7 +31,7 @@ class HtmlDiff extends AbstractDiff
      *
      * @return self
      */
-    public static function create($oldText, $newText, HtmlDiffConfig $config = null)
+    public static function create($oldText, $newText, ?HtmlDiffConfig $config = null)
     {
         $diff = new self($oldText, $newText);
 


### PR DESCRIPTION
This PR fixes some errors in our test pipelines recently with PHP 8.4 and expecting explicit nulllable types.

Would be good to get this merged and released upstream, we are currently using a patch for now.