### PR TITLE
Removed E_DEPRECATED error explicit nullable types

### DIFF
--- a/lib/Caxy/HtmlDiff/Table/AbstractTableElement.php
+++ b/lib/Caxy/HtmlDiff/Table/AbstractTableElement.php
@@ -17,7 +17,7 @@ abstract class AbstractTableElement
      *
      * @param \DOMElement|null $domNode
      */
-    public function __construct(\DOMElement $domNode = null)
+    public function __construct(?\DOMElement $domNode = null)
     {
         $this->domNode = $domNode;
     }

--- a/lib/Caxy/HtmlDiff/Table/TableCell.php
+++ b/lib/Caxy/HtmlDiff/Table/TableCell.php
@@ -25,7 +25,7 @@ class TableCell extends AbstractTableElement
      *
      * @return $this
      */
-    public function setRow(TableRow $row = null)
+    public function setRow(?TableRow $row = null)
     {
         $this->row = $row;
 

--- a/lib/Caxy/HtmlDiff/Table/TableDiff.php
+++ b/lib/Caxy/HtmlDiff/Table/TableDiff.php
@@ -54,7 +54,7 @@ class TableDiff extends AbstractDiff
      *
      * @return self
      */
-    public static function create($oldText, $newText, HtmlDiffConfig $config = null)
+    public static function create($oldText, $newText, ?HtmlDiffConfig $config = null)
     {
         $diff = new self($oldText, $newText);
 
@@ -549,7 +549,7 @@ class TableDiff extends AbstractDiff
      *
      * @return \DOMElement
      */
-    protected function getNewCellNode(TableCell $oldCell = null, TableCell $newCell = null)
+    protected function getNewCellNode(?TableCell $oldCell = null, ?TableCell $newCell = null)
     {
         // If only one cell exists, use it
         if (!$oldCell || !$newCell) {
@@ -654,7 +654,7 @@ class TableDiff extends AbstractDiff
      * @param Table         $table
      * @param \DOMNode|null $node
      */
-    protected function parseTable(Table $table, \DOMNode $node = null)
+    protected function parseTable(Table $table, ?\DOMNode $node = null)
     {
         if ($node === null) {
             $node = $table->getDomNode();

--- a/lib/Caxy/HtmlDiff/Table/TableRow.php
+++ b/lib/Caxy/HtmlDiff/Table/TableRow.php
@@ -30,7 +30,7 @@ class TableRow extends AbstractTableElement
      *
      * @return $this
      */
-    public function setTable(Table $table = null)
+    public function setTable(?Table $table = null)
     {
         $this->table = $table;
 


### PR DESCRIPTION
This PR solves the E_DEPRECATED errors such as:

```
Caxy\\HtmlDiff\\HtmlDiffConfig::setCacheProvider(): Implicitly marking parameter $cacheProvider as nullable is deprecated, the explicit nullable type must be used instead
```
in file caxy/php-htmldiff/lib/Caxy/HtmlDiff/HtmlDiffConfig.php

See also https://www.php.net/manual/en/migration84.deprecated.php

After merging this PR, please make a new release as well, such that users of composer can update easily.