### PR TITLE
Fix: Removed some more E_DEPRECATED error explicit nullable types

### DIFF
--- a/lib/Caxy/HtmlDiff/HtmlDiffConfig.php
+++ b/lib/Caxy/HtmlDiff/HtmlDiffConfig.php
@@ -400,7 +400,7 @@ class HtmlDiffConfig
      *
      * @return $this
      */
-    public function setCacheProvider(\Doctrine\Common\Cache\Cache $cacheProvider = null)
+    public function setCacheProvider(?\Doctrine\Common\Cache\Cache $cacheProvider = null)
     {
         $this->cacheProvider = $cacheProvider;
 

--- a/lib/Caxy/HtmlDiff/LcsService.php
+++ b/lib/Caxy/HtmlDiff/LcsService.php
@@ -17,7 +17,7 @@ class LcsService
      *
      * @param MatchStrategyInterface $matchStrategy
      */
-    public function __construct(MatchStrategyInterface $matchStrategy = null)
+    public function __construct(?MatchStrategyInterface $matchStrategy = null)
     {
         if (null === $matchStrategy) {
             $matchStrategy = new EqualMatchStrategy();

--- a/lib/Caxy/HtmlDiff/ListDiffLines.php
+++ b/lib/Caxy/HtmlDiff/ListDiffLines.php
@@ -51,7 +51,7 @@ class ListDiffLines extends AbstractDiff
      *
      * @return ListDiffLines
      */
-    public static function create($oldText, $newText, HtmlDiffConfig $config = null)
+    public static function create($oldText, $newText, ?HtmlDiffConfig $config = null)
     {
         $diff = new self($oldText, $newText);
 


### PR DESCRIPTION
I found some more deprecations warnings similar to https://github.com/caxy/php-htmldiff/pull/132