### PR TITLE
Replace overly permissive 0777 cache permissions with 0775.

### DIFF
--- a/lib/Caxy/HtmlDiff/AbstractDiff.php
+++ b/lib/Caxy/HtmlDiff/AbstractDiff.php
@@ -140,7 +140,7 @@ abstract class AbstractDiff
         // Cache.SerializerPermissions defaults to 0744.
         // This setting allows the cache files to be deleted by any user, as they are typically
         // created by the web/php user (www-user, php-fpm, etc.)
-        $HTMLPurifierConfig->set('Cache.SerializerPermissions', 0777);
+        $HTMLPurifierConfig->set('Cache.SerializerPermissions', 0775);
 
         $this->purifier = new HTMLPurifier($HTMLPurifierConfig);
     }


### PR DESCRIPTION
The cache directory is created with file permissions 0777 which seems overly permissive as it allows any user to (over)write files in this directory.

How about tightening permissions to 0775?

For context we use this library via Drupal's [Diff](https://www.drupal.org/project/diff) module. In Drupal the default chmod for directories is also 0775 https://github.com/drupal/core/blob/11.x/lib/Drupal/Core/File/FileSystem.php#L37